### PR TITLE
fix: remove devops ticket

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,3 @@
 :construction: Remaining work:
 
 - 
-
-:ticket: Associated DevOps ticket:
-
-- 


### PR DESCRIPTION
:wrench: Changes in this PR:

- Updated this template to remove devops ticket

:books: Documentation

- N/A

:construction: Remaining work:

- none

:ticket: Associated DevOps ticket:

- RETURN TO THE SERVERED HELL FROM WHENCE YOU CAME DEMON-QUESTION
